### PR TITLE
remove media 500px for section hebergement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -371,23 +371,13 @@ footer ul {
         }
 
         .hebergements-cards {
-            display: grid;
-            grid-template-columns: repeat(2, minmax(0, 1fr));
             margin: 15px 0px;
         }
 
         /***** activité et footer *********/
-
         footer {
             gap: 50px;
             padding: 30px;
-        }
-        /* Very small devices (small phones, less than 500px) */
-        @media (max-width: 500.00px) {
-            .hebergements-cards {
-                display: flex;
-                flex-direction: column;
-            }
         }
     }
 }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                     <div class="hebergements-title">
                         <h2 class="section-title margin-0">Hébergements à Marseille</h2>
                     </div>
-                    <div class="hebergements-cards gap-30 mobile-gap-15">
+                    <div class="hebergements-cards gap-30 mobile-gap-15 mobile-display-flex mobile-flex-column">
                         <a href="#">
                             <article class="card display-flex flex-column">
                                 <img src="images/hebergements/fred-kleber.jpg" alt="Image de la chambre d'hôtel montrant un lit">


### PR DESCRIPTION
Remove media query for 500px for hebergement section, to get the same design as the figma mobile model.